### PR TITLE
Future-proof against inference changes

### DIFF
--- a/src/messages/stream/event.rs
+++ b/src/messages/stream/event.rs
@@ -112,7 +112,7 @@ macro_rules! impl_event {
                                 } else {
                                     v.visit_value::<IgnoredAny>()?;
                                 },
-                                _ => { v.visit_value()?; },
+                                _ => { v.visit_value::<()>()?; },
                             }
 
                             if let EventBuffer {


### PR DESCRIPTION
Hi,

Some recent [future-compatibility testing](https://github.com/rust-lang/rust/pull/39009#issuecomment-276806189) showed up an issue in this crate. In the future, creating a value of type `T` where `T` is unspecified and can't be inferred will cause the compiler to either give an error or default `T` to `!` (where it currently defaults to `()`).

This PR makes it so you're explicitly asking for a `()` from the map.