### PR TITLE
Tokio integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+branches:
+  only:
+  - master
+  - /^v\d+\.\d+\.x$/
 language: rust
 rust:
   - stable
@@ -14,6 +18,3 @@ env:
   - FEATURES=
   - FEATURES=egg-mode
   - FEATURES=tweetust
-  - FEATURES=tls-native-tls
-  - FEATURES=tls-openssl
-  - FEATURES=tls-rustls

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ A library for listening on Twitter Streaming API.
 chrono = { version = ">= 0.2, < 0.4", features = ["serde"] }
 flate2 = "0.2"
 futures = "0.1"
-hyper = { version = "0.11.0-a", git = "https://github.com/hyperium/hyper/", rev = "34509ef51a60082fa7888c5d75eb38aaf9d3ceec" }
+hyper = { version = "0.11.0-a", git = "https://github.com/hyperium/hyper/" }
 hyper-tls = { version = "0.0", git = "https://github.com/hyperium/hyper-tls/" }
 lazy_static = "0.2"
 oauthcli = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ A library for listening on Twitter Streaming API.
 """
 
 [dependencies]
+bytes = "0.4"
 chrono = { version = ">= 0.2, < 0.4", features = ["serde"] }
 flate2 = "0.2"
 futures = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,23 +17,14 @@ A library for listening on Twitter Streaming API.
 chrono = { version = ">= 0.2, < 0.4", features = ["serde"] }
 flate2 = "0.2"
 futures = "0.1"
-hyper = "0.10"
+hyper = { version = "0.11.0-a", git = "https://github.com/hyperium/hyper/", rev = "34509ef51a60082fa7888c5d75eb38aaf9d3ceec" }
+hyper-tls = { version = "0.0", git = "https://github.com/hyperium/hyper-tls/" }
 lazy_static = "0.2"
 oauthcli = "1.0"
 serde = "0.9"
 serde_derive = "0.9"
 serde_json = "0.9"
+tokio-core = "= 0.1"
 url = "1.0"
 egg-mode = { version = "0.8", optional = true }
 tweetust = { version = "0.5", optional = true }
-hyper-native-tls = { version = "0.2", optional = true }
-native-tls = { version = "0.1", optional = true }
-hyper-openssl = { version = "0.2", optional = true }
-openssl = { version = "0.9", optional = true }
-hyper-rustls = { version = "0.3", optional = true }
-
-[features]
-default = ["tls-native-tls"]
-tls-native-tls = ["hyper-native-tls", "native-tls"]
-tls-openssl = ["hyper-openssl", "openssl"]
-tls-rustls = ["hyper-rustls"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,6 +34,7 @@ pub enum StreamError {
     Utf8(Utf8Error),
 }
 
+#[derive(Debug)]
 pub enum JsonStreamError {
     Hyper(HyperError),
     TimedOut,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,28 +1,21 @@
 //! Error types
 
-pub use default_client::Error as TlsError;
 pub use hyper::Error as HyperError;
 pub use json::Error as JsonError;
 
 use message::Disconnect;
 use std::error::Error as StdError;
 use std::fmt::{self, Display, Formatter};
-use std::result;
 use std::io;
 use types::StatusCode;
 
 /// An error occurred while trying to connect to a Stream.
-#[allow(unreachable_patterns)]
 #[derive(Debug)]
 pub enum Error {
-    /// An error occured while parsing the gzip header of the response from the server.
-    Gzip(io::Error),
     /// An HTTP error from the Stream.
     Http(StatusCode),
     /// An error from the `hyper` crate.
     Hyper(HyperError),
-    /// An error occured when initializing a TLS client.
-    Tls(TlsError),
 }
 
 /// An error occured while listening on a Stream.
@@ -36,30 +29,22 @@ pub enum StreamError {
     Json(JsonError),
 }
 
-pub type Result<T> = result::Result<T, Error>;
-
 impl StdError for Error {
     fn description(&self) -> &str {
         use Error::*;
 
-        #[allow(unreachable_patterns)]
         match *self {
-            Gzip(ref e) => e.description(),
             Http(ref status) => status.canonical_reason().unwrap_or("<unknown status code>"),
             Hyper(ref e) => e.description(),
-            Tls(ref e) => e.description(),
         }
     }
 
     fn cause(&self) -> Option<&StdError> {
         use Error::*;
 
-        #[allow(unreachable_patterns)]
         match *self {
-            Gzip(ref e) => Some(e),
             Http(_) => None,
             Hyper(ref e) => Some(e),
-            Tls(ref e) => Some(e),
         }
     }
 }
@@ -90,12 +75,9 @@ impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         use Error::*;
 
-        #[allow(unreachable_patterns)]
         match *self {
-            Gzip(ref e) => Display::fmt(e, f),
             Http(ref code) => Display::fmt(code, f),
             Hyper(ref e) => Display::fmt(e, f),
-            Tls(ref e) => Display::fmt(e, f),
         }
     }
 }
@@ -121,13 +103,6 @@ impl From<JsonError> for StreamError {
 impl From<StatusCode> for Error {
     fn from(e: StatusCode) -> Self {
         Error::Http(e)
-    }
-}
-
-// Assuming that `TlsError` is not `JsonError`, `StatusCode`, `UrlError`, `HyperError` or `io::Error`.
-impl From<TlsError> for Error {
-    fn from(e: TlsError) -> Self {
-        Error::Tls(e)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,7 @@ use message::Disconnect;
 use std::error::Error as StdError;
 use std::fmt::{self, Display, Formatter};
 use std::io;
+use std::str::Utf8Error;
 use types::StatusCode;
 
 /// An error occurred while trying to connect to a Stream.
@@ -23,10 +24,17 @@ pub enum Error {
 pub enum StreamError {
     /// The Stream has been disconnected by the server.
     Disconnect(Disconnect),
+    Hyper(HyperError),
     /// An I/O error.
     Io(io::Error),
     /// Failed to parse a JSON message from a Stream.
     Json(JsonError),
+    Utf8(Utf8Error),
+}
+
+pub enum JsonStreamError {
+    Hyper(HyperError),
+    Utf8(Utf8Error),
 }
 
 impl StdError for Error {
@@ -55,8 +63,10 @@ impl StdError for StreamError {
 
         match *self {
             Disconnect(ref d) => &d.reason,
+            Hyper(ref e) => e.description(),
             Io(ref e) => e.description(),
             Json(ref e) => e.description(),
+            Utf8(ref e) => e.description(),
         }
     }
 
@@ -65,8 +75,10 @@ impl StdError for StreamError {
 
         match *self {
             Disconnect(_) => None,
+            Hyper(ref e) => Some(e),
             Io(ref e) => Some(e),
             Json(ref e) => Some(e),
+            Utf8(ref e) => Some(e),
         }
     }
 }
@@ -88,9 +100,32 @@ impl Display for StreamError {
 
         match *self {
             Disconnect(ref d) => Display::fmt(d, f),
+            Hyper(ref e) => Display::fmt(e, f),
             Io(ref e) => Display::fmt(e, f),
             Json(ref e) => Display::fmt(e, f),
+            Utf8(ref e) => Display::fmt(e, f),
         }
+    }
+}
+
+impl From<JsonStreamError> for StreamError {
+    fn from(e: JsonStreamError) -> Self {
+        match e {
+            JsonStreamError::Hyper(e) => StreamError::Hyper(e),
+            JsonStreamError::Utf8(e) => StreamError::Utf8(e),
+        }
+    }
+}
+
+impl From<HyperError> for JsonStreamError {
+    fn from(e: HyperError) -> Self {
+        JsonStreamError::Hyper(e)
+    }
+}
+
+impl From<Utf8Error> for JsonStreamError {
+    fn from(e: Utf8Error) -> Self {
+        JsonStreamError::Utf8(e)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,7 @@ pub use user::User;
 
 use error::HyperError;
 use futures::{Future, Poll, Stream};
+use hyper::Uri;
 use hyper::client::{Client, Connect, FutureResponse, Request, Response};
 use hyper::header::{Headers, AcceptEncoding, ContentType, Encoding, UserAgent, qitem};
 use hyper_tls::HttpsConnector;
@@ -480,7 +481,7 @@ impl<'a, _CH> TwitterStreamBuilder<'a, _CH> {
             headers.set(auth::create_authorization_header(t, &self.method, &url, Some(body.as_ref())));
             headers.set(ContentType(Mime(TopLevel::Application, SubLevel::WwwFormUrlEncoded, Vec::new())));
 
-            let mut req = Request::new(RequestMethod::Post, url);
+            let mut req = Request::new(RequestMethod::Post, url.as_ref().parse().unwrap());
             *req.headers_mut() = headers;
             req.set_body(body.into_bytes());
 
@@ -489,7 +490,7 @@ impl<'a, _CH> TwitterStreamBuilder<'a, _CH> {
             self.append_query_pairs(&mut url.query_pairs_mut());
             headers.set(auth::create_authorization_header(t, &self.method, &url, None));
 
-            let mut req = Request::new(self.method.clone(), url);
+            let mut req = Request::new(self.method.clone(), url.as_ref().parse().unwrap());
             *req.headers_mut() = headers;
 
             c.request(req)

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 //! Common types used across the crate.
 
-pub use hyper::method::Method as RequestMethod;
+pub use hyper::Method as RequestMethod;
 pub use hyper::status::StatusCode;
 pub use json::Map as JsonMap;
 pub use json::Number as JsonNumber;

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,7 +7,10 @@ pub use json::Number as JsonNumber;
 pub use json::Value as JsonValue;
 pub use url::Url;
 
+use bytes::Bytes;
 use chrono::{DateTime as ChronoDateTime, UTC};
+use std::ops::Deref;
+use std::str::{self, Utf8Error};
 
 string_enums! {
     /// Represents the `filter_level` field in Tweets or `filter_level` parameter in API request.
@@ -42,6 +45,75 @@ string_enums! {
 }
 
 pub type DateTime = ChronoDateTime<UTC>;
+
+/// A string type returned by `TwitterJsonStream`.
+// It is basically a wrapper type over `Bytes` that gurantees the contained bytes are valid UTF8 string.
+// Inspired by hyper::http::str::ByteStr.
+#[derive(Clone, PartialEq, PartialOrd, Ord, Eq, Debug, Hash)]
+pub struct JsonStr {
+    inner: Bytes,
+}
+
+impl JsonStr {
+    #[doc(hidden)]
+    pub fn from_utf8(v: Bytes) -> Result<Self, Utf8Error> {
+        str::from_utf8(&v)?;
+        unsafe { Ok(JsonStr::from_utf8_unchecked(v)) }
+    }
+
+    pub fn from_static(s: &'static str) -> Self {
+        JsonStr {
+            inner: Bytes::from_static(s.as_ref()),
+        }
+    }
+
+    #[doc(hidden)]
+    pub unsafe fn from_utf8_unchecked(v: Bytes) -> Self {
+        JsonStr {
+            inner: v,
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        unsafe { str::from_utf8_unchecked(&self.inner) }
+    }
+}
+
+impl AsRef<str> for JsonStr {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Deref for JsonStr {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl From<String> for JsonStr {
+    fn from(s: String) -> Self {
+        JsonStr {
+            inner: s.into_bytes().into(),
+        }
+    }
+}
+
+impl<'a> From<&'a str> for JsonStr {
+    fn from(s: &'a str) -> Self {
+        JsonStr {
+            inner: s.into(),
+        }
+    }
+}
+
+impl From<JsonStr> for Bytes {
+    fn from(s: JsonStr) -> Self {
+        s.inner
+    }
+}
 
 impl ::std::default::Default for FilterLevel {
     fn default() -> Self {

--- a/src/util.rs
+++ b/src/util.rs
@@ -315,16 +315,16 @@ mod test {
             "wxyz",
         ];
         let body = vec![
-            Bytes::from_static(b"abc\r\n"),
+            Bytes::from(b"abc\r\n".to_vec()),
             Bytes::from(b"d\r\nefg\r\n".to_vec()),
-            Bytes::from_static(b"hi"),
+            Bytes::from(b"hi".to_vec()),
             Bytes::from(b"jk".to_vec()),
             Bytes::from(b"\r\n".to_vec()),
-            Bytes::from_static(b"\r\n"),
+            Bytes::from(b"\r\n".to_vec()),
             Bytes::from(b"lmn\r\nop".to_vec()),
             Bytes::from(b"q\rrs\r".to_vec()),
-            Bytes::from_static(b"\n\n\rtuv\r\r\n"),
-            Bytes::from_static(b"wxyz"),
+            Bytes::from(b"\n\n\rtuv\r\r\n".to_vec()),
+            Bytes::from(b"wxyz".to_vec()),
         ];
 
         let mut iter1 = lines.iter().cloned();

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,11 @@
+use bytes::{BufMut, Bytes};
 use chrono::{TimeZone, UTC};
-use serde::de::{Deserialize, Deserializer, Error};
+use error::JsonStreamError;
+use futures::{Poll, Stream};
+use futures::stream::Fuse;
+use serde::de::{Deserialize, Deserializer, Error as SerdeError};
+use std::time::Duration;
+use tokio_core::reactor::{Handle, Timeout};
 use types::DateTime;
 
 macro_rules! string_enums {
@@ -96,6 +102,126 @@ macro_rules! string_enums {
     }
 }
 
+pub struct TimeoutStream<S> {
+    stream: S,
+    inner: Option<TSInner>,
+}
+
+/// A stream over the lines (delimited by CRLF) of a `Body`.
+pub struct Lines<B> where B: Stream {
+    inner: Fuse<B>,
+    buf: Bytes,
+}
+
+struct TSInner {
+    dur: Duration,
+    handle: Handle,
+    timer: Timeout,
+}
+
+impl<S> TimeoutStream<S> {
+    pub fn new(stream: S, dur: Option<Duration>, handle: Handle) -> Self {
+        TimeoutStream {
+            stream: stream,
+            inner: dur.and_then(|dur| {
+                Timeout::new(dur, &handle).ok().map(|timer| {
+                    TSInner {
+                        dur: dur,
+                        handle: handle,
+                        timer: timer,
+                    }
+                })
+            }),
+        }
+    }
+}
+
+impl<S> Stream for TimeoutStream<S> where S: Stream, S::Error: Into<JsonStreamError> {
+    type Item = S::Item;
+    type Error = JsonStreamError;
+
+    fn poll(&mut self) -> Poll<Option<S::Item>, JsonStreamError> {
+        if let Some(ref _inner) = self.inner {
+            unimplemented!();
+        } else {
+            self.stream.poll().map_err(Into::into)
+        }
+    }
+}
+
+impl<B> Lines<B> where B: Stream {
+    pub fn new(body: B) -> Self {
+        Lines {
+            inner: body.fuse(),
+            buf: Bytes::new(),
+        }
+    }
+}
+
+impl<B> Stream for Lines<B> where B: Stream, B::Item: Into<Bytes> {
+    type Item = Bytes;
+    type Error = B::Error;
+
+    fn poll(&mut self) -> Poll<Option<Bytes>, B::Error> {
+        use std::mem;
+
+        macro_rules! try_ready_some {
+            ($poll:expr) => {{
+                let poll = $poll;
+                match try_ready!(poll) {
+                    Some(v) => v,
+                    None    => return Ok(None.into()),
+                }
+            }};
+        }
+
+        if self.buf.is_empty() {
+            self.buf = try_ready_some!(self.inner.poll()).into();
+        }
+
+        fn remove_next_line(buf: &mut Bytes) -> Option<Bytes> {
+            (buf as &Bytes).into_iter().enumerate()
+                .find(|&(i, b)| b'\r' == b && Some(&b'\n') == buf.get(i + 1))
+                .map(|(i, _)| buf.split_off(i + 2))
+        }
+
+        if let Some(buf) = remove_next_line(&mut self.buf) {
+            let ret = mem::replace(&mut self.buf, buf);
+            return Ok(Some(ret).into());
+        }
+
+        if self.buf.is_empty() {
+            self.buf = try_ready_some!(self.inner.poll()).into();
+        }
+
+        // Extend the buffer until a newline is found:
+        loop {
+            match try_ready!(self.inner.poll()) {
+                Some(chunk) => {
+                    let mut chunk = chunk.into();
+                    if &b'\r' == self.buf.last().unwrap() && Some(&b'\n') == chunk.first() {
+                        let i = self.buf.len() + 1;
+                        extend_from_bytes(&mut self.buf, chunk);
+                        let next = self.buf.split_off(i);
+                        let ret = mem::replace(&mut self.buf, next);
+                        return Ok(Some(ret).into());
+                    } else if let Some(next) = remove_next_line(&mut chunk) {
+                        extend_from_bytes(&mut self.buf, chunk);
+                        let ret = mem::replace(&mut self.buf, next);
+                        return Ok(Some(ret).into());
+                    } else {
+                        extend_from_bytes(&mut self.buf, chunk);
+                    }
+                },
+                None => {
+                    let ret = mem::replace(&mut self.buf, Bytes::new());
+                    return Ok(Some(ret).into());
+                },
+            };
+        }
+    }
+}
+
 pub fn parse_datetime(s: &str) -> ::chrono::format::ParseResult<DateTime> {
     UTC.datetime_from_str(s, "%a %b %e %H:%M:%S %z %Y")
 }
@@ -104,3 +230,70 @@ pub fn deserialize_datetime<D: Deserializer>(d: D) -> Result<DateTime, D::Error>
     parse_datetime(&String::deserialize(d)?).map_err(|e| D::Error::custom(e.to_string()))
 }
 
+// XXX: possibly can be replaced with carllerche/bytes#85
+fn extend_from_bytes(dst: &mut Bytes, src: Bytes) {
+    use std::mem;
+
+    if src.is_empty() { return; }
+
+    // Temporary swap just to take the ownership
+    let buf = mem::replace(dst, src);
+
+    *dst = match buf.try_mut() {
+        Ok(mut buf) => {
+            buf.reserve(dst.len());
+            buf.put_slice(dst);
+            buf.freeze()
+        },
+        Err(buf) => {
+            let mut buf = buf.to_vec();
+            buf.extend_from_slice(dst);
+            buf.into()
+        },
+    };
+}
+
+#[cfg(test)]
+mod test {
+    use bytes::Bytes;
+    use futures::stream;
+    use super::*;
+
+    #[test]
+    fn lines() {
+        let lines = vec![
+            "abc\r\n",
+            "d\r\n",
+            "efg\r\n",
+            "hijk\r\n",
+            "\r\n",
+            "lmn\r\n",
+            "opq\rrs\r\n",
+            "\n\rtuv\r\r\n",
+            "wxyz",
+        ];
+        let body = vec![
+            Bytes::from_static(b"abc\r\n"),
+            Bytes::from(b"d\r\nefg\r\n".to_vec()),
+            Bytes::from_static(b"hi"),
+            Bytes::from(b"jk".to_vec()),
+            Bytes::from(b"\r\n".to_vec()),
+            Bytes::from_static(b"\r\n"),
+            Bytes::from(b"lmn\r\nop".to_vec()),
+            Bytes::from(b"q\rrs\r".to_vec()),
+            Bytes::from_static(b"\n\n\rtuv\r\r\n"),
+            Bytes::from_static(b"wxyz"),
+        ];
+
+        let mut iter1 = lines.iter().cloned();
+        let mut iter2 = Lines::new(stream::iter::<_,_,()>(body.into_iter().map(Ok)))
+            .wait().map(|s| String::from_utf8(s.unwrap().to_vec()).unwrap());
+
+        for _ in 0..(lines.len()+1) {
+            assert_eq!(
+                iter1.next(),
+                iter2.next().as_ref().map(String::as_str)
+            );
+        }
+    }
+}


### PR DESCRIPTION
This adds Tokio support to the library. It introduces several breaking changes.

* The library now requires hyper 0.11
* The user has to manage an event loop
* `TwitterJsonStream` returns a new type `JsonStr` that derefs to `str`
* TLS implementation features (`tls-native-tls`, `tls-openssl` and `tls-rustls`) was removed (may be re-added in the future)

```rust
extern crate futures;
extern crate tokio_core;
extern crate twitter_stream;

use futures::{Future, Stream};
use tokio_core::reactor::Core;
use twitter_stream::{StreamMessage, Token, TwitterStreamBuilder};

fn main() {
    let token = Token::new("consumer_key", "consumer_secret", "access_key", "access_secret");

    let mut core = Core::new().unwrap();
    let handle = core.handle();

    let builder = TwitterStreamBuilder::user().handle(&handle);

    let fut_stream = builder.listen_json(&token);
    let stream = core.run(fut_stream).unwrap();

    let fut = stream.for_each(|json| {
        println!("{:?}", json);
        Ok(())
    });
    core.run(fut).unwrap();
}
```

Closes #4.